### PR TITLE
Fix issue one with short tag

### DIFF
--- a/site/templates/articles.php
+++ b/site/templates/articles.php
@@ -39,7 +39,7 @@
 			<p>    						
 				<?php if($articles->pagination()->hasPrevPage()): ?>
 				<a class="prev" href="<?= $articles->pagination()->prevPageURL() ?>">« Previous</a>
-				<? endif ?>
+				<?php endif ?>
 				
 				<?php if($articles->pagination()->hasPrevPage() && $articles->pagination()->hasNextPage()): ?>
 				|


### PR DESCRIPTION
Short PHP tag used in one place in articles.php template file results in parser error on some installations with short tag support set off. Fix that by changing to regular PHP tag
